### PR TITLE
Fixed error creating Zip Files in some environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 vendor
+
+# PHPStorm settings
+.idea

--- a/src/Passbook/PassFactory.php
+++ b/src/Passbook/PassFactory.php
@@ -215,7 +215,7 @@ class PassFactory
         // Zip pass
         $zipFile = $outputPath . $pass->getSerialNumber() . self::PASS_EXTENSION;
         $zip = new ZipArchive();
-        if (!$zip->open($zipFile, $this->isOverwrite() ? ZIPARCHIVE::OVERWRITE : ZipArchive::CREATE)) {
+        if (!$zip->open($zipFile, $this->isOverwrite() ? ZipArchive::OVERWRITE | ZipArchive::CREATE : ZipArchive::CREATE)) {
             throw new FileException("Couldn't open zip file.");
         }
         if ($handle = opendir($passDir)) {


### PR DESCRIPTION
Hi,

When push my implementation of passbook to the production environment I was getting the next errors:

Warning: ZipArchive::addFile(): Invalid or uninitialized Zip object in /{myRoot}/vendor/eo/passbook/src/Passbook/PassFactory.php on line 224

Warning: ZipArchive::close(): Invalid or uninitialized Zip object in /{myRoot}/vendor/eo/passbook/src/Passbook/PassFactory.php on line 230

My development environment configuration;
PHP-FPM: 5.4.36-0+deb7u3
Nginx: 1.7.9

My production environment configuration:
HHVM: 3.5.0
Nginx: 1.7.9

Folder to create passes permissions and owner: 777 www-data

I checked the paths, the permissions, and a lot of things more but i can't resolve the problem.

Finally I found the solution in PHP.net page (http://php.net/manual/en/ziparchive.open.php#88765)

For some reason when not exists the ZipArchive and open it with the parameter ZIPARCHIVE::OVERWRITE returning an error.