### PR TITLE
Forced extension for images to PNG 

### DIFF
--- a/src/Passbook/PassFactory.php
+++ b/src/Passbook/PassFactory.php
@@ -225,7 +225,9 @@ class PassFactory
             if ($image->isRetina()) {
                 $fileName .= '@2x';
             }
-            $fileName .= '.' . $image->getExtension();
+	    // Extension is forced to '.png' because when Image is created
+	    // by passing an URL 'getExtension' also returns query string parameters 
+            $fileName .= '.png';
             copy($image->getPathname(), $fileName);
         }
 


### PR DESCRIPTION
Forced extension for images to PNG to avoid problem with images created via URL with query string.

When you create an Image passing an URL that contains parameters `getExtension()` returns also the query string.

```
$foo = new Image("http://www.test.com/myimage.png?w=100");
echo $foo->getExtension();

// png?w=100
```

This create not valid filename for images like `strip@2x.png?w=100`

_Note_
AFAIK Wallet only accept PNG images so IMHO Image should throw an exception if a non PNG file is passed.
