### PR TITLE
PassInvalidException now returns an exception message

### DIFF
--- a/src/Passbook/Exception/PassInvalidException.php
+++ b/src/Passbook/Exception/PassInvalidException.php
@@ -8,12 +8,19 @@ namespace Passbook\Exception;
 class PassInvalidException extends \RuntimeException
 {
     /**
+     * @var array
+     */
+    protected $errors;
+
+    /**
      * Construct a PassInvalidException either with or without an array of errors.
      *
+     * @param string        $string
      * @param string[]|null $errors
      */
-    public function __construct(array $errors = null)
+    public function __construct($message = '', array $errors = null)
     {
+        parent::__construct($message);
         $this->errors = $errors ? $errors : array();
     }
 

--- a/src/Passbook/Exception/PassInvalidException.php
+++ b/src/Passbook/Exception/PassInvalidException.php
@@ -15,7 +15,7 @@ class PassInvalidException extends \RuntimeException
     /**
      * Construct a PassInvalidException either with or without an array of errors.
      *
-     * @param string        $string
+     * @param string        $message
      * @param string[]|null $errors
      */
     public function __construct($message = '', array $errors = null)

--- a/src/Passbook/PassFactory.php
+++ b/src/Passbook/PassFactory.php
@@ -251,7 +251,7 @@ class PassFactory
 
         if ($this->passValidator) {
             if (!$this->passValidator->validate($pass)){
-                throw new PassInvalidException($this->passValidator->getErrors());
+                throw new PassInvalidException('Failed to validate passbook', $this->passValidator->getErrors());
             };
         }
 

--- a/tests/Passbook/Tests/Exception/PassInvalidExceptionTest.php
+++ b/tests/Passbook/Tests/Exception/PassInvalidExceptionTest.php
@@ -17,10 +17,20 @@ class PassInvalidExceptionTest extends \PHPUnit_Framework_TestCase
     public function testNewExceptionWithErrorsArray()
     {
         $errors = array('error 1', 'error 2');
-        $exception = new PassInvalidException($errors);
+        $exception = new PassInvalidException('', $errors);
 
         self::assertTrue(is_array($exception->getErrors()));
         self::assertEquals($errors, $exception->getErrors());
+    }
+
+    public function testNewExceptionWithMessageAndArray()
+    {
+        $errors = array('error 1', 'error 2');
+        $exception = new PassInvalidException('Exception message', $errors);
+
+        self::assertTrue(is_array($exception->getErrors()));
+        self::assertEquals($errors, $exception->getErrors());
+        self::assertSame('Exception message', $exception->getMessage());
     }
 
 }


### PR DESCRIPTION
We recently updated the package at work and it broke our passbook implementation. We weren't able to determine that a new validation for image type had been added as the PassInvalidException was not returning any message.

This fix will set an exception message and the error array properly.