### PR TITLE
added support for groupingIdentifier iOS 7.0+

### DIFF
--- a/src/Passbook/Pass.php
+++ b/src/Passbook/Pass.php
@@ -155,6 +155,15 @@ class Pass implements PassInterface
     protected $foregroundColor;
 
     /**
+     * Identifier used to group related passes. 
+     * If a grouping identifier is specified, passes with the same style, pass type identifier, 
+     * and grouping identifier are displayed as a group. Otherwise, passes are grouped automatically.
+     *
+     * @var string
+     */
+    protected $groupingIdentifier;
+
+    /**
      * Color of the label text, specified as a CSS-style RGB triple.
      *
      * @var string rgb(255, 255, 255)
@@ -265,6 +274,7 @@ class Pass implements PassInterface
             'barcodes',
             'backgroundColor',
             'foregroundColor',
+            'groupingIdentifier',
             'labelColor',
             'logoText',
             'suppressStripShine',
@@ -604,6 +614,24 @@ class Pass implements PassInterface
     public function getForegroundColor()
     {
         return $this->foregroundColor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setGroupingIdentifier($groupingIdentifier)
+    {
+        $this->groupingIdentifier = $groupingIdentifier;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGroupingIdentifier()
+    {
+        return $this->groupingIdentifier;
     }
 
     /**

--- a/src/Passbook/PassInterface.php
+++ b/src/Passbook/PassInterface.php
@@ -190,6 +190,16 @@ interface PassInterface extends ArrayableInterface
     /**
      * {@inheritdoc}
      */
+    public function setGroupingIdentifier($groupingIdentifier);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGroupingIdentifier();
+
+    /**
+     * {@inheritdoc}
+     */
     public function setLabelColor($labelColor);
 
     /**

--- a/src/Passbook/PassValidator.php
+++ b/src/Passbook/PassValidator.php
@@ -43,6 +43,7 @@ class PassValidator implements PassValidatorInterface
     const ASSOCIATED_STORE_IDENTIFIER_INVALID = 'associatedStoreIdentifiers is invalid; must be an integer';
     const ASSOCIATED_STORE_IDENTIFIER_REQUIRED = 'appLaunchURL is required when associatedStoreIdentifiers is present';
     const IMAGE_TYPE_INVALID = 'image files must be PNG format';
+    const GROUPING_IDENTITY_INVALID = 'the grouping identity may only be used on boarding pass and event ticket types';
 
     /**
      * {@inheritdoc}
@@ -59,6 +60,7 @@ class PassValidator implements PassValidatorInterface
         $this->validateIcon($pass);
         $this->validateImageType($pass);
         $this->validateAssociatedStoreIdentifiers($pass);
+        $this->validateGroupingIdentity($pass);
 
         return count($this->errors) === 0;
     }
@@ -234,6 +236,15 @@ class PassValidator implements PassValidatorInterface
 
                 return;
             }
+        }
+    }
+
+    private function validateGroupingIdentity(PassInterface $pass)
+    {
+        if (null !== $pass->getType() && !in_array($pass->getType(), ['boardingPass', 'eventTicket'])) {
+            $this->addError(self::GROUPING_IDENTITY_INVALID);
+
+            return;
         }
     }
 

--- a/tests/Passbook/Tests/PassTest.php
+++ b/tests/Passbook/Tests/PassTest.php
@@ -173,6 +173,9 @@ class PassTest extends \PHPUnit_Framework_TestCase
         // Set pass structure
         $this->eventTicket->setStructure($structure);
 
+        // Set grouping
+        $this->eventTicket->setGroupingIdentifier('group1');
+
         // Add barcode
         $barcode = new Barcode('PKBarcodeFormatQR', 'barcodeMessage');
         $this->eventTicket->setBarcode($barcode);
@@ -187,6 +190,7 @@ class PassTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('backgroundColor', $array);
         $this->assertArrayHasKey('eventTicket', $array);
         $this->assertArrayHasKey('relevantDate', $array);
+        $this->assertArrayHasKey('groupingIdentifier', $array);
     }
 
     /**
@@ -247,6 +251,7 @@ class PassTest extends \PHPUnit_Framework_TestCase
             ->setBackgroundColor('rgb(0, 255, 0)')
             ->setLabelColor('rgb(0, 255, 0)')
             ->setAuthenticationToken('123')
+            ->setGroupingIdentifier('group1')
             ->setType('generic')
             ->setSuppressStripShine(false)
             ->setAppLaunchURL('http://app.launch.url')
@@ -259,6 +264,7 @@ class PassTest extends \PHPUnit_Framework_TestCase
             'backgroundColor',
             'labelColor',
             'authenticationToken',
+            'groupingIdentifier',
             'suppressStripShine',
             'associatedStoreIdentifiers',
             'appLaunchURL',

--- a/tests/Passbook/Tests/PassValidatorTest.php
+++ b/tests/Passbook/Tests/PassValidatorTest.php
@@ -231,6 +231,25 @@ class PassValidatorTest extends \PHPUnit_Framework_TestCase
         $this->pass->addImage($jpg);
         $this->assertFails($this->pass, PassValidator::IMAGE_TYPE_INVALID);
     }
+
+    public function testGroupingIdentity()
+    {
+        $this->pass->setType('boardingPass');
+        $this->pass->setGroupingIdentifier('group1');
+        $this->assertPasses($this->pass, PassValidator::GROUPING_IDENTITY_INVALID);
+
+        $this->pass->setType('eventTicket');
+        $this->pass->setGroupingIdentifier('group1');
+        $this->assertPasses($this->pass, PassValidator::GROUPING_IDENTITY_INVALID);
+
+        $this->pass->setType('coupon');
+        $this->pass->setGroupingIdentifier('group1');
+        $this->assertFails($this->pass, PassValidator::GROUPING_IDENTITY_INVALID);
+
+        $this->pass->setType('storeCard');
+        $this->pass->setGroupingIdentifier('group1');
+        $this->assertFails($this->pass, PassValidator::GROUPING_IDENTITY_INVALID);
+    }
     
     private function assertFails($pass, $expectedError)
     {


### PR DESCRIPTION
Support for groupingIdentifier to allow multiple passes to be displayed side by side, useful for trips with connection flights (multiple boarding passes), and multiple event tickets on the same order.