### PR TITLE
Return float values of latitude, longitude and altitude

### DIFF
--- a/src/Passbook/Pass/Location.php
+++ b/src/Passbook/Pass/Location.php
@@ -84,7 +84,7 @@ class Location implements LocationInterface
      */
     public function getAltitude()
     {
-        return $this->altitude !== null ? floatval($this->altitude) : null;
+        return is_numeric($this->altitude) ? floatval($this->altitude) : null;
     }
 
     /**
@@ -102,7 +102,7 @@ class Location implements LocationInterface
      */
     public function getLatitude()
     {
-        return $this->latitude !== null ? floatval($this->latitude) : null;
+        return is_numeric($this->latitude) ? floatval($this->latitude) : null;
     }
 
     /**
@@ -120,7 +120,7 @@ class Location implements LocationInterface
      */
     public function getLongitude()
     {
-        return $this->longitude !== null ? floatval($this->longitude) : null;
+        return is_numeric($this->longitude) ? floatval($this->longitude) : null;
     }
 
     /**

--- a/src/Passbook/Pass/Location.php
+++ b/src/Passbook/Pass/Location.php
@@ -120,7 +120,7 @@ class Location implements LocationInterface
      */
     public function getLongitude()
     {
-        return $this-longitude !== null ? floatval($this->longitude) : null;
+        return $this->longitude !== null ? floatval($this->longitude) : null;
     }
 
     /**

--- a/src/Passbook/Pass/Location.php
+++ b/src/Passbook/Pass/Location.php
@@ -84,7 +84,7 @@ class Location implements LocationInterface
      */
     public function getAltitude()
     {
-        return floatval($this->altitude);
+        return $this->altitude !== null ? floatval($this->altitude) : null;
     }
 
     /**
@@ -102,7 +102,7 @@ class Location implements LocationInterface
      */
     public function getLatitude()
     {
-        return floatval($this->latitude);
+        return $this->latitude !== null ? floatval($this->latitude) : null;
     }
 
     /**
@@ -120,7 +120,7 @@ class Location implements LocationInterface
      */
     public function getLongitude()
     {
-        return floatval($this->longitude);
+        return $this-longitude !== null ? floatval($this->longitude) : null;
     }
 
     /**

--- a/src/Passbook/Pass/Location.php
+++ b/src/Passbook/Pass/Location.php
@@ -84,7 +84,7 @@ class Location implements LocationInterface
      */
     public function getAltitude()
     {
-        return is_numeric($this->altitude) ? floatval($this->altitude) : null;
+        return is_numeric($this->altitude) ? floatval($this->altitude) : $this->altitude;
     }
 
     /**
@@ -102,7 +102,7 @@ class Location implements LocationInterface
      */
     public function getLatitude()
     {
-        return is_numeric($this->latitude) ? floatval($this->latitude) : null;
+        return is_numeric($this->latitude) ? floatval($this->latitude) : $this->latitude;
     }
 
     /**
@@ -120,7 +120,7 @@ class Location implements LocationInterface
      */
     public function getLongitude()
     {
-        return is_numeric($this->longitude) ? floatval($this->longitude) : null;
+        return is_numeric($this->longitude) ? floatval($this->longitude) : $this->longitude;
     }
 
     /**

--- a/src/Passbook/Pass/Location.php
+++ b/src/Passbook/Pass/Location.php
@@ -84,7 +84,7 @@ class Location implements LocationInterface
      */
     public function getAltitude()
     {
-        return $this->altitude;
+        return floatval($this->altitude);
     }
 
     /**
@@ -102,7 +102,7 @@ class Location implements LocationInterface
      */
     public function getLatitude()
     {
-        return $this->latitude;
+        return floatval($this->latitude);
     }
 
     /**
@@ -120,7 +120,7 @@ class Location implements LocationInterface
      */
     public function getLongitude()
     {
-        return $this->longitude;
+        return floatval($this->longitude);
     }
 
     /**


### PR DESCRIPTION
Return float values of latitude, longitude, and altitude instead of strings because Android app Wallet doesn't accept integer ones.