### PR TITLE
 Rework `Image` class to allow images with dynamic format change

### DIFF
--- a/src/Passbook/Pass/Image.php
+++ b/src/Passbook/Pass/Image.php
@@ -40,12 +40,19 @@ class Image extends \SplFileObject implements ImageInterface
      */
     protected $density;
 
-    public function __construct($filename, $context)
+    /**
+     * Force "png" extension in case of dynamic conversion of the file, i.e. by CDN.
+     *
+     * @var bool
+     */
+    protected $forceExtension;
+
+    public function __construct($filename, $context, $forceExtension = false)
     {
-        // Call parent
-        parent::__construct($filename);
-        // Pass image context
-        $this->setContext($context);
+        parent::__construct($filename, $context);
+
+        $this->context = $context;
+        $this->forceExtension = $forceExtension;
     }
 
     /**
@@ -82,5 +89,18 @@ class Image extends \SplFileObject implements ImageInterface
     public function getDensity()
     {
         return $this->density;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtension()
+    {
+        if ($this->forceExtension) {
+            return 'png';
+        }
+
+        // Image pathname can be URL not only local file location
+        return pathinfo(parse_url($this->getPathname(), PHP_URL_PATH), PATHINFO_EXTENSION);
     }
 }

--- a/src/Passbook/Pass/Image.php
+++ b/src/Passbook/Pass/Image.php
@@ -49,7 +49,7 @@ class Image extends \SplFileObject implements ImageInterface
 
     public function __construct($filename, $context, $forceExtension = false)
     {
-        parent::__construct($filename, $context);
+        parent::__construct($filename);
 
         $this->context = $context;
         $this->forceExtension = $forceExtension;

--- a/src/Passbook/PassFactory.php
+++ b/src/Passbook/PassFactory.php
@@ -492,8 +492,7 @@ class PassFactory
                 $fileName .= '@3x';
             }
 
-            // Image pathname can be URL not only local file location
-            $fileName .= '.' . pathinfo(parse_url($image->getPathname(), PHP_URL_PATH), PATHINFO_EXTENSION);
+            $fileName .= '.' . $image->getExtension();
             copy($image->getPathname(), $fileName);
         }
     }

--- a/src/Passbook/PassValidator.php
+++ b/src/Passbook/PassValidator.php
@@ -212,8 +212,7 @@ class PassValidator implements PassValidatorInterface
     private function validateImageType(PassInterface $pass)
     {
         foreach ($pass->getImages() as $image) {
-            $ext = pathinfo($image->getFilename(), PATHINFO_EXTENSION);
-            if (strcasecmp('png', $ext)) {
+            if ('png' !== strtolower($image->getExtension())) {
                 $this->addError(self::IMAGE_TYPE_INVALID);
             }
         }


### PR DESCRIPTION
This PR allows forcing file extension while i.e. using CDN like "imgix.com" which allows to force the stored image to be returned in totally different format: `jpeg -> png`.

@eymengunay Can you check this make sense to you? Thanks :)