### PR TITLE
missed "userInfo" property

### DIFF
--- a/src/Passbook/Pass.php
+++ b/src/Passbook/Pass.php
@@ -246,6 +246,13 @@ class Pass implements PassInterface
      */
     protected $appLaunchURL;
 
+	/**
+	 * Pass userInfo
+	 *
+	 * @var mixed
+	 */
+	protected $userInfo;
+
     public function __construct($serialNumber, $description)
     {
         // Required
@@ -287,6 +294,7 @@ class Pass implements PassInterface
             'voided',
             'appLaunchURL',
             'associatedStoreIdentifiers',
+	        'userInfo'
         );
         foreach ($properties as $property) {
             $method = 'is' . ucfirst($property);
@@ -306,12 +314,12 @@ class Pass implements PassInterface
                 $array[$property] = $val;
             } elseif (is_array($val)) {
                 // Array
-                foreach ($val as $v) {
+                foreach ($val as $k => $v) {
                     if (is_object($v)) {
                         /* @var ArrayableInterface $v */
-                        $array[$property][] = $v->toArray();
+                        $array[$property][$k] = $v->toArray();
                     } else {
-                        $array[$property][] = $v;
+                        $array[$property][$k] = $v;
                     }
                 }
             }
@@ -831,4 +839,21 @@ class Pass implements PassInterface
     {
         return $this->appLaunchURL;
     }
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUserInfo($userInfo) {
+		$this->userInfo = $userInfo;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getUserInfo() {
+		return $this->userInfo;
+	}
+
 }

--- a/src/Passbook/PassInterface.php
+++ b/src/Passbook/PassInterface.php
@@ -299,4 +299,14 @@ interface PassInterface extends ArrayableInterface
      */
     public function getAppLaunchURL();
 
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUserInfo($userInfo);
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getUserInfo();
+
 }


### PR DESCRIPTION
I didn't find `"userInfo"` property in your wonderful library, but I really was needed it in my project. According [Apple documentation](https://developer.apple.com/library/content/documentation/UserExperience/Reference/PassKit_Bundle/Chapters/TopLevel.html) this field can be defined but is optional. So I added it. 
I didn't test if it need validation, but in docs we see type of this field "_any JSON data_".
In addition, I slightly changed the `toArray` method, I added preserving keys in the resulting array in order not to lose keys in my `userInfo` associative array.
Looks like it works fine)