### PR TITLE
Fix: isOverwrite() not honored while preparing localizations (#92).

### DIFF
--- a/src/Passbook/PassFactory.php
+++ b/src/Passbook/PassFactory.php
@@ -507,7 +507,12 @@ class PassFactory
         foreach ($pass->getLocalizations() as $localization) {
             // Create dir (LANGUAGE.lproj)
             $localizationDir = $passDir . $localization->getLanguage() . '.lproj' . DIRECTORY_SEPARATOR;
-            mkdir($localizationDir, 0777, true);
+            $localizationDirExists = file_exists($localizationDir);
+            if ($localizationDirExists && !$this->isOverwrite()) {
+                throw new FileException("Temporary pass localization directory already exists ({$localization->getLanguage()})");
+            } elseif (!$localizationDirExists && !mkdir($localizationDir, 0777, true)) {
+                throw new FileException("Couldn't create temporary pass localization directory ({$localization->getLanguage()})");
+            }
 
             // pass.strings File (Format: "token" = "value")
             $localizationStringsFile = $localizationDir . 'pass.strings';


### PR DESCRIPTION
When generating the pass package, an error occurred if any localization directory already existed, since the method always tried to create it. This change makes the prepareLocalizations() method behave in the same way as preparePassDirectory(), that is, only try to create the directory if it does not exist, and do nothing if it exists and isOverwrite() is true (fixes issue #92 )