### PR TITLE
Fix: Incompatible Image::getExtension return type deprecation notice

### DIFF
--- a/src/Passbook/Pass.php
+++ b/src/Passbook/Pass.php
@@ -82,14 +82,14 @@ class Pass implements PassInterface
      * @var array
      */
     protected $beacons = [];
-    
+
     /**
      * NFC where the pass is relevant.
      *
      * @var array
      */
     protected $nfc = [];
-    
+
 
     /**
      * A list of iTunes Store item identifiers (also known as Adam IDs) for the
@@ -185,8 +185,8 @@ class Pass implements PassInterface
      * @var string
      */
     protected $logoText;
-    
-    
+
+
 
     /**
      * If true, the strip image is displayed without a shine effect.
@@ -761,7 +761,7 @@ class Pass implements PassInterface
      */
     public function getAuthenticationToken()
     {
-        return $this->authenticationToken;
+        return (string) $this->authenticationToken;
     }
 
     /**

--- a/src/Passbook/Pass/DateField.php
+++ b/src/Passbook/Pass/DateField.php
@@ -84,7 +84,7 @@ class DateField extends Field
      */
     public function getDateStyle()
     {
-        return $this->dateStyle;
+        return (string) $this->dateStyle;
     }
 
     /**
@@ -139,7 +139,7 @@ class DateField extends Field
      */
     public function getTimeStyle()
     {
-        return $this->timeStyle;
+        return (string) $this->timeStyle;
     }
 
     /**

--- a/src/Passbook/Pass/Image.php
+++ b/src/Passbook/Pass/Image.php
@@ -94,6 +94,7 @@ class Image extends \SplFileObject implements ImageInterface
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function getExtension()
     {
         if ($this->forceExtension) {


### PR DESCRIPTION
According to an issue #97 I think it would be more convinient to add ```#[\ReturnTypeWillChange]``` attribute to remove the deprecation notice and keep code compatible with previous versions of PHP