### PR TITLE
Add support for relevantDates array (iOS 18.0+)

### DIFF
--- a/src/Passbook/Pass.php
+++ b/src/Passbook/Pass.php
@@ -18,6 +18,7 @@ use Passbook\Pass\NfcInterface;
 use Passbook\Pass\ImageInterface;
 use Passbook\Pass\LocalizationInterface;
 use Passbook\Pass\LocationInterface;
+use Passbook\Pass\RelevantDateInterface;
 use Passbook\Pass\Structure;
 use Passbook\Pass\StructureInterface;
 
@@ -125,6 +126,14 @@ class Pass implements PassInterface
      * @var DateTime
      */
     protected $relevantDate;
+
+    /**
+     * Start and end date and times for the pass relevancy interval.
+     * For example, the start time and end time of a movie.
+     *
+     * @var array
+     */
+    protected $relevantDates;
 
     /**
      * Maximum distance in meters from a relevant latitude and longitude that
@@ -304,6 +313,7 @@ class Pass implements PassInterface
             'locations',
             'maxDistance',
             'relevantDate',
+            'relevantDates',
             'barcode',
             'barcodes',
             'backgroundColor',
@@ -564,6 +574,24 @@ class Pass implements PassInterface
     public function getRelevantDate()
     {
         return $this->relevantDate;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addRelevantDate(RelevantDateInterface $relevantDate)
+    {
+        $this->relevantDates[] = $relevantDate;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRelevantDates()
+    {
+        return $this->relevantDates;
     }
 
     /**

--- a/src/Passbook/Pass/RelevantDate.php
+++ b/src/Passbook/Pass/RelevantDate.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Passbook package.
+ *
+ * (c) Eymen Gunay <eymen@egunay.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Passbook\Pass;
+
+/**
+ * Relevant Dates
+ *
+ * @author Christian Freear <https://github.com/cfreear>
+ */
+class RelevantDate implements RelevantDateInterface
+{
+    /**
+     * Relevant date and time.
+     * @var \DateTime
+     */
+    protected $date;
+
+    /**
+     * End of the pass relevancy interval.
+     * @var \DateTime
+     */
+    protected $endDate;
+
+    /**
+     * Start of the pass relevancy interval.
+     * @var \DateTime
+     */
+    protected $startDate;
+
+    public function toArray()
+    {
+        $array = [
+            'date' => $this->getDate(),
+            'endDate' => $this->getEndDate(),
+            'startDate' => $this->getStartDate()
+        ];
+
+        if ($date = $this->getDate()) {
+            $array['date'] = $date;
+        }
+
+        if ($endDate = $this->getEndDate()) {
+            $array['endDate'] = $endDate;
+        }
+
+        if ($startDate = $this->getStartDate()) {
+            $array['startDate'] = $startDate;
+        }
+
+        return $array;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEndDate($endDate)
+    {
+        $this->endDate = $endDate;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndDate()
+    {
+        return $this->endDate;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStartDate($startDate)
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStartDate()
+    {
+        return $this->startDate;
+    }
+}

--- a/src/Passbook/Pass/RelevantDateInterface.php
+++ b/src/Passbook/Pass/RelevantDateInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Passbook package.
+ *
+ * (c) Eymen Gunay <eymen@egunay.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Passbook\Pass;
+
+use Passbook\ArrayableInterface;
+
+/**
+ * RelevantDateInterface
+ *
+ * @author Christian Freear <https://github.com/cfreear>
+ */
+interface RelevantDateInterface extends ArrayableInterface
+{
+    /**
+     * Sets relevant date and time
+     *
+     * @param \DateTime $datetime
+     */
+    public function setDate($datetime);
+
+    /**
+     * Gets relevant date and time
+     *
+     * @return \DateTime
+     */
+    public function getDate();
+
+    /**
+     * Sets the pass relevancy interval end date
+     *
+     * @param \DateTime $datetime
+     */
+    public function setEndDate($datetime);
+
+    /**
+     * Gets the pass relevancy interval end date
+     *
+     * @return \DateTime
+     */
+    public function getEndDate();
+
+    /**
+     * Sets the pass relevancy interval start date
+     *
+     * @param \DateTime $datetime
+     */
+    public function setStartDate($datetime);
+
+    /**
+     * Gets the pass relevancy interval start date
+     *
+     * @return \DateTime
+     */
+    public function getStartDate();
+}

--- a/tests/Passbook/Tests/Pass/RelevantDateTest.php
+++ b/tests/Passbook/Tests/Pass/RelevantDateTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Passbook\Tests\Pass;
+
+use Passbook\Pass\RelevantDate;
+use PHPUnit\Framework\TestCase;
+
+class RelevantDateTest extends TestCase
+{
+    public function testRelevantDate()
+    {
+        $relevantDate = new RelevantDate();
+        $relevantDate
+            ->setDate(new \DateTime('2026-06-10 14:00:00'))
+            ->setEndDate(new \DateTime('2026-06-10 16:59:59'))
+            ->setStartDate(new \DateTime('2026-06-10 14:00:00'))
+        ;
+
+        $this->assertEquals(new \DateTime('2026-06-10 14:00:00'), $relevantDate->getDate());
+        $this->assertEquals(new \DateTime('2026-06-10 16:59:59'), $relevantDate->getEndDate());
+        $this->assertEquals(new \DateTime('2026-06-10 14:00:00'), $relevantDate->getStartDate());
+
+        $expected = [
+            'date' => new \DateTime('2026-06-10 14:00:00'),
+            'endDate' => new \DateTime('2026-06-10 16:59:59'),
+            'startDate' => new \DateTime('2026-06-10 14:00:00')
+        ];
+
+        $this->assertEquals($expected, $relevantDate->toArray());
+    }
+}

--- a/tests/Passbook/Tests/PassTest.php
+++ b/tests/Passbook/Tests/PassTest.php
@@ -173,6 +173,14 @@ class PassTest extends TestCase
         // Relevant date
         $this->eventTicket->setRelevantDate(new DateTime());
 
+        // Add relevant date interval
+        $relevantDate = new Pass\RelevantDate();
+        $relevantDate
+            ->setDate(new DateTime('2026-06-10 14:00:00'))
+            ->setEndDate(new DateTime('2026-06-10 16:59:59'))
+            ->setStartDate(new DateTime('2026-06-10 14:00:00'));
+        $this->eventTicket->addRelevantDate($relevantDate);
+
         // Set pass structure
         $this->eventTicket->setStructure($structure);
 
@@ -193,6 +201,7 @@ class PassTest extends TestCase
         $this->assertArrayHasKey('backgroundColor', $array);
         $this->assertArrayHasKey('eventTicket', $array);
         $this->assertArrayHasKey('relevantDate', $array);
+        $this->assertArrayHasKey('relevantDates', $array);
         $this->assertArrayHasKey('groupingIdentifier', $array);
     }
 


### PR DESCRIPTION
Add support for relevant date intervals (start and end datetime) via `relevantDates` field on iOS 18.0+

See:
[Apple Docs](https://developer.apple.com/documentation/walletpasses/pass/relevantdates-data.dictionary)

Setting both `relevantDate` and `relevantDates` maintains compatibility for older devices. 